### PR TITLE
Fix path problems on windows by making sure to use forward slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path        = require('path');
 var request 	= require('request');
 var querystring = require('querystring');
 var parser 		= require('http-string-parser');
@@ -142,7 +143,9 @@ function GoogleBatch(){
 GoogleBatch.require = function(moduleName){
 	if(moduleName === "googleapis"){
 		try{
-            var data = "module.exports = require('" + __dirname + "/transport.js');"
+            // Make sure that forward slashes are used on windows
+            var transportJsPath = path.join(__dirname, '/transport.js').replace(/\\/g, '/');
+            var data = "module.exports = require('" + transportJsPath + "');"
             var existingGoogle = require.resolve(moduleName);
             if(existingGoogle){
                 existingGoogle = existingGoogle.substr(0, existingGoogle.indexOf(moduleName)) + 'googleapis/lib/transporters.js';


### PR DESCRIPTION
On a windows machine `__dirname` contains something like `c:\dev\project\node_modules` etc.
and of course this causes problems when written into the transports.js file like this:
`module.exports = require('c:\dev\project\node_modules\...\...');`
because backslash is used as an escape character.

My fix makes sure to use only forward slashes like this: 
`module.exports = require('c:/dev/project/node_modules/.../...');`

This way it will work on unix and windows systems too, I've tested it.
Please make a new release so others can use it too.
