### PR TITLE
Improved error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function GoogleBatch(){
 		}
 		var req = request(opts);
 		req.on('error', function (e) {
-			return callback([e]);
+			return callback(e);
 		});
 	    req.on('response', function (res) {
 	    	var boundary = res.headers['content-type'].split('boundary=');


### PR DESCRIPTION
- there was still one callback returning an array of errors (which was changed a while ago for most callbacks)
- I added a check for the statusCode response (google returns code 400 when a batch is not formed properly) which I think is a more accurate check than the header content-type
- some whitespace-only indentation fixes
