### PR TITLE
googleapis require a relative path not full url. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function getMultipart(calls){
 		var options = {
 			'Content-Type': 'application/http',
 			'Content-ID' : contentId,
-			'body' : 'GET ' + opts.url + (Object.keys(opts.qs).length ? '?' + querystring.stringify(opts.qs) : "") +  '\n'
+			'body' : 'GET ' + opts.path + (Object.keys(opts.qs).length ? '?' + querystring.stringify(opts.qs) : "") +  '\n'
 		};
 		if(opts.method !== "GET"){
 			options.body +=  'Content-Type: application/json'  + '\n\n' +


### PR DESCRIPTION
Had to change in order to get this to work.

Look at this example from the batches: https://developers.google.com/gmail/api/guides/batch#example

Notice the farm app api doesn't have the full path.

Thanks ahead
